### PR TITLE
Statements do not reserve connections

### DIFF
--- a/retrieving.md
+++ b/retrieving.md
@@ -120,6 +120,9 @@ can triple the number of database interactions your application makes! Some
 drivers can avoid this in specific cases with an addition to `database/sql` in
 Go 1.1, but not all drivers are smart enough to do that. Caveat Emptor.
 
+Naturally prepared statements and the managment of prepared statements cost
+resources. You should take care to close statements when they are not used again.
+
 Single-Row Queries
 ==================
 

--- a/retrieving.md
+++ b/retrieving.md
@@ -2,7 +2,7 @@
 layout: page
 permalink: /retrieving/
 title: Retrieving Result Sets
-tags: 
+tags:
 image:
   feature: abstract-5.jpg
 share: false
@@ -26,7 +26,7 @@ Fetching Data from the Database
 Let's take a look at an example of how to query the database, working with
 results. We'll query the `users` table for a user whose `id` is 1, and print out
 the user's `id` and `name`.  We will assign results to variables, a row at a
-time, with `rows.Scan()`. 
+time, with `rows.Scan()`.
 
 	var (
 		id int
@@ -119,13 +119,6 @@ statement. That's three round-trips to the database. If you're not careful, you
 can triple the number of database interactions your application makes! Some
 drivers can avoid this in specific cases with an addition to `database/sql` in
 Go 1.1, but not all drivers are smart enough to do that. Caveat Emptor.
-
-Statements are like results: they claim a connection and should be closed. It's
-idiomatic to `defer stmt.Close()` if the prepared statement `stmt` should not
-have a lifetime beyond the scope of the function. If you don't, it'll reserve a
-connection from the pool, and can cause resource exhaustion. (Note that for
-efficiency you should always close statements, rows, transactions, etc as soon
-as you can.)
 
 Single-Row Queries
 ==================

--- a/surprises.md
+++ b/surprises.md
@@ -2,7 +2,7 @@
 layout: page
 permalink: /surprises/
 title: Surprises, Antipatterns and Limitations
-tags: 
+tags:
 image:
   feature: abstract-5.jpg
 share: false
@@ -20,7 +20,7 @@ you can certainly cause trouble for yourself, usually by consuming some
 resources or preventing them from being reused effectively:
 
 * Opening and closing databases can cause exhaustion of resources.
-* Failing to use `rows.Close()` or `stmt.Close()` reserves connections from the pool.
+* Failing to read all rows or use `rows.Close()` reserves connections from the pool.
 * Using `Query()` for a statement that doesn't return rows will reserve a connection from the pool.
 * Failing to use prepared statements can lead to a lot of extra database activity.
 


### PR DESCRIPTION
Where did you get this information from? Did you observe some kind of resource exhaustion because of statements?
Statements do not reserve any connections and AFAIK they also do not keep any connections open.

I've seen a lot of cases where people prepared statements, executed them once and immediately closed them again, although the exact same query was made frequently.
I think the changed paragraph motivates people even further to do things like this.
