### PR TITLE
changed markdown parser from cramdown to default (redcarpet)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -41,30 +41,15 @@ links:
     external: true
 
 # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-timezone:    America/New_York
+timezone:    UTC
 future:      true
 pygments:    true
-markdown:    kramdown
 
 # https://github.com/mojombo/jekyll/wiki/Permalinks
 permalink:   /:categories/:title
 
 # Amount of post to show on home page
 paginate: 5
-
-kramdown:
-  auto_ids: true
-  footnote_nr: 1
-  entity_output: as_char
-  toc_levels: 1..6
-  use_coderay: true
-
-  coderay:
-    coderay_line_numbers: nil
-    coderay_line_numbers_start: 1
-    coderay_tab_width: 4
-    coderay_bold_every: 10
-    coderay_css: class
 
 include: [".htaccess"]
 exclude: ["lib", "config.rb", "Capfile", "config", "log", "Rakefile", "Rakefile.rb", "tmp", "less", "*.sublime-project", "*.sublime-workspace", "test", "spec", "Gruntfile.js", "package.json", "node_modules"]

--- a/importing.md
+++ b/importing.md
@@ -25,10 +25,12 @@ drivers](https://github.com/go-sql-driver/mysql) from @arnehormann and
 
 Add the following to the top of your Go source file:
 
-	import (
-		"database/sql"
-		_ "github.com/go-sql-driver/mysql"
-	)
+```go
+import (
+	"database/sql"
+	_ "github.com/go-sql-driver/mysql"
+)
+```
 
 Notice that we're loading the driver anonymously, aliasing its package qualifier
 to `_` so none of its exported names are visible to our code. Under the hood,

--- a/modifying.md
+++ b/modifying.md
@@ -20,23 +20,25 @@ Use `Exec()`, preferably with a prepared statement, to accomplish an `INSERT`,
 `UPDATE`, `DELETE`, or other statement that doesn't return rows. The following
 example shows how to insert a row and inspect metadata about the operation:
 
-	stmt, err := db.Prepare("INSERT INTO users(name) VALUES(?)")
-	if err != nil {
-		log.Fatal(err)
-	}
-	res, err := stmt.Exec("Dolly")
-	if err != nil {
-		log.Fatal(err)
-	}
-	lastId, err := res.LastInsertId()
-	if err != nil {
-		log.Fatal(err)
-	}
-	rowCnt, err := res.RowsAffected()
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Printf("ID = %d, affected = %d\n", lastId, rowCnt)
+```go
+stmt, err := db.Prepare("INSERT INTO users(name) VALUES(?)")
+if err != nil {
+	log.Fatal(err)
+}
+res, err := stmt.Exec("Dolly")
+if err != nil {
+	log.Fatal(err)
+}
+lastId, err := res.LastInsertId()
+if err != nil {
+	log.Fatal(err)
+}
+rowCnt, err := res.RowsAffected()
+if err != nil {
+	log.Fatal(err)
+}
+log.Printf("ID = %d, affected = %d\n", lastId, rowCnt)
+```
 
 Executing the statement produces a `sql.Result` that gives access to statement
 metadata: the last inserted ID and the number of rows affected.
@@ -45,8 +47,10 @@ What if you don't care about the result? What if you just want to execute a
 statement and check if there were any errors, but ignore the result? Wouldn't
 the following two statements do the same thing?
 
-	_, err := db.Exec("DELETE FROM users")  // OK
-	_, err := db.Query("DELETE FROM users") // BAD
+```go
+_, err := db.Exec("DELETE FROM users")  // OK
+_, err := db.Query("DELETE FROM users") // BAD
+```
 
 The answer is no. They do **not** do the same thing, and **you should never use
 `Query()` like this.** The `Query()` will return a `sql.Rows`, which reserves a

--- a/nulls.md
+++ b/nulls.md
@@ -15,16 +15,18 @@ package to handle them, or define your own.
 There are types for nullable booleans, strings, integers, and floats. Here's how
 you use them:
 
-	for rows.Next() {
-		var s sql.NullString
-		err := rows.Scan(&s)
-		// check err
-		if s.Valid {
-		   // use s.String
-		} else {
-		   // NULL value
-		}
+```go
+for rows.Next() {
+	var s sql.NullString
+	err := rows.Scan(&s)
+	// check err
+	if s.Valid {
+	   // use s.String
+	} else {
+	   // NULL value
 	}
+}
+```
 
 Limitations of the nullable types, and reasons to avoid nullable columns in case
 you need more convincing:

--- a/retrieving.md
+++ b/retrieving.md
@@ -28,26 +28,28 @@ results. We'll query the `users` table for a user whose `id` is 1, and print out
 the user's `id` and `name`.  We will assign results to variables, a row at a
 time, with `rows.Scan()`.
 
-	var (
-		id int
-		name string
-	)
-	rows, err := db.Query("select id, name from users where id = ?", 1)
+```go
+var (
+	id int
+	name string
+)
+rows, err := db.Query("select id, name from users where id = ?", 1)
+if err != nil {
+	log.Fatal(err)
+}
+defer rows.Close()
+for rows.Next() {
+	err := rows.Scan(&id, &name)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer rows.Close()
-	for rows.Next() {
-		err := rows.Scan(&id, &name)
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Println(id, name)
-	}
-	err = rows.Err()
-	if err != nil {
-		log.Fatal(err)
-	}
+	log.Println(id, name)
+}
+err = rows.Err()
+if err != nil {
+	log.Fatal(err)
+}
+```
 
 Here's what's happening in the above code:
 
@@ -100,19 +102,21 @@ In MySQL, the parameter placeholder is `?`, and in PostgreSQL it is `$N`, where
 N is a number. In Oracle placeholders begin with a colon and are named, like
 `:param1`. We'll use `?` because we're using MySQL as our example.
 
-	stmt, err := db.Prepare("select id, name from users where id = ?")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer stmt.Close()
-	rows, err := stmt.Query(1)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		// ...
-	}
+```go
+stmt, err := db.Prepare("select id, name from users where id = ?")
+if err != nil {
+	log.Fatal(err)
+}
+defer stmt.Close()
+rows, err := stmt.Query(1)
+if err != nil {
+	log.Fatal(err)
+}
+defer rows.Close()
+for rows.Next() {
+	// ...
+}
+```
 
 Under the hood, `db.Query()` actually prepares, executes, and closes a prepared
 statement. That's three round-trips to the database. If you're not careful, you
@@ -129,26 +133,30 @@ Single-Row Queries
 If a query returns at most one row, you can use a shortcut around some of the
 lengthy boilerplate code:
 
-	var name string
-	err = db.QueryRow("select name from users where id = ?", 1).Scan(&name)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(name)
+```go
+var name string
+err = db.QueryRow("select name from users where id = ?", 1).Scan(&name)
+if err != nil {
+	log.Fatal(err)
+}
+fmt.Println(name)
+```
 
 Errors from the query are deferred until `Scan()` is called, and then are
 returned from that. You can also call `QueryRow()` on a prepared statement:
 
-	stmt, err := db.Prepare("select id, name from users where id = ?")
-	if err != nil {
-		log.Fatal(err)
-	}
-	var name string
-	err = stmt.QueryRow(1).Scan(&name)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(name)
+```go
+stmt, err := db.Prepare("select id, name from users where id = ?")
+if err != nil {
+	log.Fatal(err)
+}
+var name string
+err = stmt.QueryRow(1).Scan(&name)
+if err != nil {
+	log.Fatal(err)
+}
+fmt.Println(name)
+```
 
 Go defines a special error constant, called `sql.ErrNoRows`, which is returned
 from `QueryRow()` when the result is empty. This needs to be handled as a

--- a/surprises.md
+++ b/surprises.md
@@ -30,7 +30,9 @@ Large uint64 Values
 Here's a surprising error. You can't pass big unsigned integers as parameters to
 statements if their high bit is set:
 
-	_, err := db.Exec("INSERT INTO users(id) VALUES", math.MaxUint64)
+```go
+_, err := db.Exec("INSERT INTO users(id) VALUES", math.MaxUint64)
+```
 
 This will throw an error. Be careful if you use `uint64` values, as they may
 start out small and work without error, but increment over time and start
@@ -89,7 +91,9 @@ Invoking stored procedures is driver-specific, but in the MySQL driver it can't
 be done at present. It might seem that you'd be able to call a simple
 procedure that returns a single result set, by executing something like this:
 
-	err := db.QueryRow("CALL mydb.myprocedure").Scan(&result)
+```go
+err := db.QueryRow("CALL mydb.myprocedure").Scan(&result)
+```
 
 In fact, this won't work. You'll get the following error: _Error
 1312: PROCEDURE mydb.myprocedure can't return a result set in the given
@@ -104,7 +108,9 @@ Multiple Statement Support
 The `database/sql` doesn't offer multiple-statement support. That means you
 can't do something like the following:
 
-	_, err := db.Exec("DELETE FROM tbl1; DELETE FROM tbl2")
+```go
+_, err := db.Exec("DELETE FROM tbl1; DELETE FROM tbl2")
+```
 
 Similarly, there is no way to batch statements in a transaction. Each statement
 in a transaction must be executed serially, and the resources that it holds

--- a/varcols.md
+++ b/varcols.md
@@ -18,41 +18,45 @@ with the correct number of values. For example, some forks of MySQL return
 different columns for the `SHOW PROCESSLIST` command, so you have to be prepared
 for that or you'll cause an error. Here's one way to do it; there are others:
 
-	cols, err := rows.Columns()
-	if err != nil {
-		// handle the error
-	} else {
-		dest := []interface{}{ // Standard MySQL columns
-			new(uint64), // id
-			new(string), // host
-			new(string), // user
-			new(string), // db
-			new(string), // command
-			new(uint32), // time
-			new(string), // state
-			new(string), // info
-		}
-		if len(cols) == 11 {
-			// Percona Server
-		} else if len(cols) > 8 {
-			// Handle this case
-		}
-		err = rows.Scan(dest...)
-		// Work with the values in dest
+```go
+cols, err := rows.Columns()
+if err != nil {
+	// handle the error
+} else {
+	dest := []interface{}{ // Standard MySQL columns
+		new(uint64), // id
+		new(string), // host
+		new(string), // user
+		new(string), // db
+		new(string), // command
+		new(uint32), // time
+		new(string), // state
+		new(string), // info
 	}
+	if len(cols) == 11 {
+		// Percona Server
+	} else if len(cols) > 8 {
+		// Handle this case
+	}
+	err = rows.Scan(dest...)
+	// Work with the values in dest
+}
+```
 
 If you don't know the columns or their types, you should use `sql.RawBytes`.
 
-	cols, err := rows.Columns() // Remember to check err afterwards
-	vals := make([]interface{}, len(cols))
-	for i, _ := range cols {
-		vals[i] = new(sql.RawBytes)
-	}
-	for rows.Next() {
-		err = rows.Scan(vals...)
-		// Now you can check each element of vals for nil-ness,
-		// and you can use type introspection and type assertions
-		// to fetch the column into a typed variable.
-	}
+```go
+cols, err := rows.Columns() // Remember to check err afterwards
+vals := make([]interface{}, len(cols))
+for i, _ := range cols {
+	vals[i] = new(sql.RawBytes)
+}
+for rows.Next() {
+	err = rows.Scan(vals...)
+	// Now you can check each element of vals for nil-ness,
+	// and you can use type introspection and type assertions
+	// to fetch the column into a typed variable.
+}
+```
 
 {% include toc.md %}


### PR DESCRIPTION
I don't have an easy way to check this, but it should fix syntax highlighting.
