### PR TITLE
Handle rows.Err() correctly in the Prepare() example

### DIFF
--- a/retrieving.md
+++ b/retrieving.md
@@ -112,6 +112,9 @@ defer rows.Close()
 for rows.Next() {
 	// ...
 }
+if rows.Err() != nil {
+	log.Fatal(err)
+}
 </pre>
 
 Under the hood, `db.Query()` actually prepares, executes, and closes a prepared


### PR DESCRIPTION
Since this looks like an otherwise complete example and this mistake is extremely common, I feel like it's better that rows.Err() gets looked at after the loop.

Thoughts?
