### PR TITLE
Update retrieving.md

### DIFF
--- a/retrieving.md
+++ b/retrieving.md
@@ -142,7 +142,7 @@ Errors from the query are deferred until `Scan()` is called, and then are
 returned from that. You can also call `QueryRow()` on a prepared statement:
 
 <pre class="prettyprint lang-go">
-stmt, err := db.Prepare("select id, name from users where id = ?")
+stmt, err := db.Prepare("select name from users where id = ?")
 if err != nil {
 	log.Fatal(err)
 }


### PR DESCRIPTION
Prepare statement fix, otherwise it returns "exit status 1" back to the log:

```
   sql: expected 2 destination arguments in Scan, not 1
   exit status 1
```
