### PR TITLE
Add SetConnMaxLifetime details to connection pool

### DIFF
--- a/connection-pool.md
+++ b/connection-pool.md
@@ -14,6 +14,7 @@ useful to know:
 * In Go 1.2.1 or newer, you can use `db.SetMaxOpenConns(N)` to limit the number of *total* open connections to the database. Unfortunately, a [deadlock bug](https://groups.google.com/d/msg/golang-dev/jOTqHxI09ns/x79ajll-ab4J) ([fix](https://code.google.com/p/go/source/detail?r=8a7ac002f840)) prevents `db.SetMaxOpenConns(N)` from safely being used in 1.2.
 * Connections are recycled rather fast. Setting a high number of idle connections with `db.SetMaxIdleConns(N)` can reduce this churn, and help keep connections around for reuse.
 * Keeping a connection idle for a long time can cause problems (like in [this issue](https://github.com/go-sql-driver/mysql/issues/257) with MySQL on Microsoft Azure). Try `db.SetMaxIdleConns(0)` if you get connection timeouts because a connection is idle for too long.
+* You can also specify the maximum amount of time a connection may be reused by setting `db.SetConnMaxLifetime(duration)` since reusing long lived connections may cause network issues. This closes the unused connections lazily i.e. closing expired connection may be deferred.
 
 **Previous: [Working with Unknown Columns](varcols.html)**
 **Next: [Surprises, Antipatterns and Limitations](surprises.html)**


### PR DESCRIPTION
Proposal to add information of timeout on expired connections which will be helpful while configuring connection pooling for an app.