### PR TITLE
Changes to Prepare.md to compensate for unintended  behaviour

### DIFF
--- a/prepared.md
+++ b/prepared.md
@@ -106,7 +106,7 @@ for i := 0; i < 10; i++ {
 err = tx.Commit()
 if err != nil {
 	log.Error(err)
-    tx.Rollback()
+	tx.Rollback()
 }
 // stmt.Close() runs here!
 </pre>

--- a/prepared.md
+++ b/prepared.md
@@ -89,23 +89,24 @@ transactions. Consider the following example:
 <pre class="prettyprint lang-go">
 tx, err := db.Begin()
 if err != nil {
-	log.Fatal(err)
+	log.Error(err)
 }
-defer tx.Rollback()
+
 stmt, err := tx.Prepare("INSERT INTO foo VALUES (?)")
 if err != nil {
-	log.Fatal(err)
+	log.Error(err)
 }
 defer stmt.Close() // danger!
 for i := 0; i < 10; i++ {
 	_, err = stmt.Exec(i)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
 	}
 }
 err = tx.Commit()
 if err != nil {
-	log.Fatal(err)
+	log.Error(err)
+    tx.Rollback()
 }
 // stmt.Close() runs here!
 </pre>


### PR DESCRIPTION
By using `defer tx.Rollback()` a rollback will always be attempted when a function returns, which in my opinion is seems as unintended. 
Furthermore, using `log.Fatal` actually terminates the execution, which rarely is what you want to happen. 