### PR TITLE
Possible missing stmt.Close

### DIFF
--- a/retrieving.md
+++ b/retrieving.md
@@ -167,6 +167,7 @@ stmt, err := db.Prepare("select name from users where id = ?")
 if err != nil {
 	log.Fatal(err)
 }
+defer stmt.Close()
 var name string
 err = stmt.QueryRow(1).Scan(&amp;name)
 if err != nil {


### PR DESCRIPTION
Are you missing `derfer stmt.Close` on here or you just did it on purpose? 
Please explain to us why you don't need to stmt.Close() in this scenario