### PR TITLE
Fix reference to 'db' var

### DIFF
--- a/modifying.md
+++ b/modifying.md
@@ -84,8 +84,8 @@ code. Bad things might result:
 * You could believe you're executing queries on a single connection, inside of a transaction, when in reality Go has created several connections for you invisibly and some statements aren't part of the transaction.
 
 While you are working inside a transaction you should be careful not to make
-calls to the `Db` variable. Make all of your calls to the `Tx` variable that you
-created with `db.Begin()`. The `Db` is not in a transaction, only the `Tx` is.
+calls to the `db` variable. Make all of your calls to the `Tx` variable that you
+created with `db.Begin()`. `db` is not in a transaction, only the `Tx` object is.
 If you make further calls to `db.Exec()` or similar, those will happen outside
 the scope of your transaction, on other connections.
 


### PR DESCRIPTION
In the rest of the example `db` is used, not `Db`. Moreover, I think that a simple example here could help clarify the terminology, because it gets a bit murky between `db` (object of type `DB`) and `tx` (object of type `Tx`). Something like:

```
// Create an object of type Tx
tx, err := db.Begin()
...
```