### PR TITLE
Update accessing.md

### DIFF
--- a/accessing.md
+++ b/accessing.md
@@ -24,7 +24,7 @@ In the example shown, we're illustrating several things:
 1. The first argument to `sql.Open` is the driver name. This is the string that the driver used to register itself with `database/sql`, and is conventionally the same as the package name to avoid confusion. For example, it's `mysql` for [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql). Some drivers do not follow the convention and use the database name, e.g. `sqlite3` for [github.com/mattn/go-sqlite3](https://github.com/mattn/go-sqlite3) and `postgres` for [github.com/lib/pq](https://github.com/lib/pq).
 2. The second argument is a driver-specific syntax that tells the driver how to access the underlying datastore. In this example, we're connecting to the "hello" database inside a local MySQL server instance.
 3. You should (almost) always check and handle errors returned from all `database/sql` operations.  There are a few special cases that we'll discuss later where it doesn't make sense to do this.
-4. It is idiomatic to `defer db.Close()` if the `sql.DB` should not have a lifetime beyond the scope of the function.
+4. It is idiomatic to `defer db.Close()` , because the `sql.DB` object should not have a lifetime beyond the scope of the function.
 
 Perhaps counter-intuitively, `sql.Open()` **does not establish any connections
 to the database**, nor does it validate driver connection parameters. Instead,


### PR DESCRIPTION
It seems that there is a typo here "It is idiomatic to defer db.Close() **if** the sql.DB should not have a lifetime beyond the scope of the function."
 So I tried making it more clear **because the `sql.DB` object**